### PR TITLE
feat: add file based EXEC SQL pattern registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,21 @@ A script for processing and formatting code.
 ## Usage
 
 ```bash
-python src/proc_format.py input_file output_file
+python -m proc_format input_file output_file
 ```
+
+### Configuration
+
+`proc_format` can read additional EXEC SQL parsing patterns from a file
+named `.exec-sql-parser`.  The file is searched in the directory of the
+input file and its ancestors with entries in lower directories
+overriding higher ones.  Each file is a JSON object where keys are
+pattern names.  Setting a name to `null` disables the built-in pattern;
+providing an object with `"pattern"` and optional `"end_pattern"` adds
+or replaces a pattern.  A file may contain `"root": true` to stop
+searching for configurations in higher directories.  Use
+`--no-registry-parents` to only consider the configuration file in the
+input file's directory.
 
 ## Testing
 

--- a/src/proc_format/__main__.py
+++ b/src/proc_format/__main__.py
@@ -7,11 +7,13 @@ from proc_format import process_file, ProCFormatterContext
 def main():
 
     parser = argparse.ArgumentParser(description="Format Pro*C files by aligning EXEC SQL and formatting C code.")
-    parser.add_argument("input_file", help="Input file to process.")    
+    parser.add_argument("input_file", help="Input file to process.")
     parser.add_argument("output_file", help="Output file to save the formatted content.")
     parser.add_argument("--clang-format", default="clang-format", help="Path to clang-format executable.")
     parser.add_argument("--debug", default="debug", help="Path to debug directory.")
     parser.add_argument("--keep", action="store_true", help="Do not delete debug directory before processing.")
+    parser.add_argument("--no-registry-parents", action="store_true",
+                        help="Do not search parent directories for .exec-sql-parser files.")
 
     args = parser.parse_args()
 

--- a/src/proc_format/core.py
+++ b/src/proc_format/core.py
@@ -5,7 +5,7 @@ import subprocess
 import logging
 import shutil
 
-from .registry import EXEC_SQL_REGISTRY
+from .registry import load_registry
 from .registry import re_DECLARE_BEGIN, re_DECLARE_END
 
 logging.basicConfig(level=logging.INFO)
@@ -21,7 +21,7 @@ ERRORS_TXT = "errors.txt"           # List of segments with errors, one per line
 SQL_DIR = "sql"                     # Directory with extracted EXEC SQL segments
 
 class ProCFormatterContext:
-    __slots__ = ["input_file", "output_file", "clang_format_path", "keep", "debug", "sql_dir"]
+    __slots__ = ["input_file", "output_file", "clang_format_path", "keep", "debug", "sql_dir", "registry"]
     def __init__(self, args):
         self.input_file = args.input_file
         self.output_file = args.output_file
@@ -29,6 +29,8 @@ class ProCFormatterContext:
         self.keep = args.keep
         self.debug = args.debug
         self.sql_dir = os.path.join(self.debug, SQL_DIR)
+        search = not getattr(args, 'no_registry_parents', False)
+        self.registry = load_registry(os.path.dirname(self.input_file), search)
 
 def format_name(debug_dir, *elements):
     elements = [str(e) for e in elements]
@@ -61,7 +63,7 @@ def process_file(ctx : ProCFormatterContext):
     write_file(ctx.debug, BEFORE_PC, pc_before)
 
     # Step 1: Mark EXEC SQL lines
-    marked_content, exec_sql_segments = capture_exec_sql_blocks(ctx, pc_before.splitlines())
+    marked_content, exec_sql_segments = capture_exec_sql_blocks(ctx, pc_before.splitlines(), ctx.registry)
     c_before = "\n".join(marked_content)
     write_file(ctx.debug, BEFORE_C, c_before)
 
@@ -79,7 +81,7 @@ def process_file(ctx : ProCFormatterContext):
 
     print("File processed successfully: {0}\nd".format(ctx.input_file))
 
-def capture_exec_sql_blocks(ctx, lines):
+def capture_exec_sql_blocks(ctx, lines, registry):
     """
     Parses the input lines, replacing EXEC SQL blocks with markers
     and capturing their content for later restoration.
@@ -120,7 +122,7 @@ def capture_exec_sql_blocks(ctx, lines):
                 current_stripped_line = None
                 print("b", end="")
         else:
-            for construct, details in EXEC_SQL_REGISTRY.items():
+            for construct, details in registry.items():
                 if re.match(details["pattern"], stripped_line):
                     if "error" in details:
                         raise ValueError("Unaccompanied block end marker detected at line {0}:\n{1}"

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,56 @@
+import os
+import tempfile
+import shutil
+
+from proc_format.registry import load_registry
+
+
+def write_cfg(dirpath, content):
+    path = os.path.join(dirpath, '.exec-sql-parser')
+    f = open(path, 'w')
+    f.write(content)
+    f.close()
+
+
+def test_registry_override_and_disable():
+    base = tempfile.mkdtemp()
+    try:
+        write_cfg(base, '{"STATEMENT-Single-Line [1]": null}')
+        sub = os.path.join(base, 'sub')
+        os.mkdir(sub)
+        write_cfg(sub,
+                  '{"CUSTOM": {"pattern": "EXEC SQL TEST;", "end_pattern": "END;"}}')
+        reg = load_registry(sub)
+        assert 'STATEMENT-Single-Line [1]' not in reg
+        assert reg['CUSTOM']['pattern'] == 'EXEC SQL TEST;'
+        assert 'end_pattern' in reg['CUSTOM']
+    finally:
+        shutil.rmtree(base)
+
+
+def test_registry_no_parents():
+    base = tempfile.mkdtemp()
+    try:
+        write_cfg(base, '{"STATEMENT-Single-Line [1]": null}')
+        sub = os.path.join(base, 'sub')
+        os.mkdir(sub)
+        reg = load_registry(sub, search_parents=False)
+        assert 'STATEMENT-Single-Line [1]' in reg
+    finally:
+        shutil.rmtree(base)
+
+
+def test_registry_root_stops_search():
+    base = tempfile.mkdtemp()
+    try:
+        write_cfg(base, '{"STATEMENT-Single-Line [1]": null}')
+        mid = os.path.join(base, 'mid')
+        os.mkdir(mid)
+        write_cfg(mid, '{"root": true}')
+        sub = os.path.join(mid, 'sub')
+        os.mkdir(sub)
+        reg = load_registry(sub)
+        assert 'STATEMENT-Single-Line [1]' in reg
+    finally:
+        shutil.rmtree(base)
+


### PR DESCRIPTION
## Summary
- support `.exec-sql-parser` files to disable or extend EXEC SQL patterns
- add `--no-registry-parents` flag to stop ancestor lookups
- test registry override, parent skipping, and root directive

## Testing
- `scripts/test`


------
https://chatgpt.com/codex/tasks/task_b_6894e2fd72a88326b34565214587603d