### PR TITLE
fix exec-sql regex whitespace

### DIFF
--- a/DEBUG_LOG.md
+++ b/DEBUG_LOG.md
@@ -1,0 +1,7 @@
+# Debug Log
+
+## 2025-08-08
+- Encountered failing Emacs test `exec-sql-parser-captures-execute-variants` reporting `Unterminated EXEC SQL STATEMENT-Multi-Line`.
+- Investigated `exec-sql-parser.el` registry patterns; discovered improper use of `\s*` and `\S` which are invalid in Emacs regex.
+- Updated whitespace tokens to `\s-` and `\S-` and anchored `EXECUTE-Block` end pattern.
+- Despite updates, test still reports `Unterminated EXEC SQL EXECUTE-Block`; further investigation needed into termination handling for `EXECUTE-Block` constructs.

--- a/exec-sql-parser.el
+++ b/exec-sql-parser.el
@@ -37,28 +37,28 @@
       :action #'identity)
     ;; EXEC SQL EXECUTE forms ordered to avoid masking
     ("EXECUTE-Block"
-      :pattern "^EXEC SQL EXECUTE\\s*$"
-      :end-pattern "END-EXEC;"
+      :pattern "^EXEC SQL EXECUTE\\s-*$"
+      :end-pattern "^END-EXEC;\\s-*$"
       :action #'identity)
     ("EXECUTE-Immediate-Multi"
       :pattern "^EXEC SQL EXECUTE IMMEDIATE\\b[^;]*$"
-      :end-pattern ".*;\\s*$"
+      :end-pattern ".*;\\s-*$"
       :action #'identity)
     ("EXECUTE-Prepared-Multi"
-      :pattern "^EXEC SQL EXECUTE \(?!IMMEDIATE\)\\S[^;]*$"
-      :end-pattern ".*;\\s*$"
+      :pattern "^EXEC SQL EXECUTE \(?!IMMEDIATE\)\\S-[^;]*$"
+      :end-pattern ".*;\\s-*$"
       :action #'identity)
     ("EXECUTE-Immediate-Single [1]"
-      :pattern "^EXEC SQL EXECUTE IMMEDIATE\\b[^;]*;\\s*$"
+      :pattern "^EXEC SQL EXECUTE IMMEDIATE\\b[^;]*;\\s-*$"
       :action #'identity)
     ("EXECUTE-Immediate-Single [2]"
-      :pattern "^EXEC SQL EXECUTE IMMEDIATE\\b[^;]*;\\s*$"
+      :pattern "^EXEC SQL EXECUTE IMMEDIATE\\b[^;]*;\\s-*$"
       :action #'identity)
     ("EXECUTE-Prepared-Single [1]"
-      :pattern "^EXEC SQL EXECUTE \(?!IMMEDIATE\)\\S[^;]*;\\s*$"
+      :pattern "^EXEC SQL EXECUTE \(?!IMMEDIATE\)\\S-[^;]*;\\s-*$"
       :action #'identity)
     ("EXECUTE-Prepared-Single [2]"
-      :pattern "^EXEC SQL EXECUTE \(?!IMMEDIATE\)\\S[^;]*;\\s*$"
+      :pattern "^EXEC SQL EXECUTE \(?!IMMEDIATE\)\\S-[^;]*;\\s-*$"
       :action #'identity)
     ("STATEMENT-Single-Line [1]"
       :pattern "^EXEC SQL\\b.*;"


### PR DESCRIPTION
## Summary
- ensure Emacs regex patterns use correct whitespace classes
- anchor EXECUTE-Block termination check
- record ongoing investigation into failing EXEC SQL tests

## Testing
- `emacs --batch -l tests/test_exec_sql_parser.el -f ert-run-tests-batch-and-exit` *(fails: Unterminated EXEC SQL EXECUTE-Block)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'proc_format')*

------
https://chatgpt.com/codex/tasks/task_b_68955f4dc2ec8326a14bca817cc3936a