### PR TITLE
Fix EXEC SQL EXECUTE with connection clause

### DIFF
--- a/src/proc_format/registry.py
+++ b/src/proc_format/registry.py
@@ -68,7 +68,8 @@ DEFAULT_EXEC_SQL_REGISTRY = {
     },
 
     "EXECUTE-BEGIN-END-Multi-Line": {
-        "pattern": r"EXEC SQL EXECUTE\b",
+        # Allow optional connection specification (e.g. "AT :db") before EXECUTE
+        "pattern": r"EXEC SQL\s+(AT\s+\S+\s+)?EXECUTE\b",
         "end_pattern": r"END-EXEC;",  # Block termination
         "action": lambda lines: lines  # Maintain original content
     },

--- a/tests/test_capture_exec_sql.py
+++ b/tests/test_capture_exec_sql.py
@@ -1,0 +1,27 @@
+import os
+from proc_format.core import capture_exec_sql_blocks
+from proc_format.registry import load_registry
+
+
+def test_execute_with_at_connection(tmp_path):
+    sql_dir = tmp_path / 'sql'
+    os.makedirs(str(sql_dir))
+    ctx = type('Ctx', (), {'sql_dir': str(sql_dir)})
+    lines = [
+        'EXEC SQL INCLUDE SQLCA;',
+        '',
+        'void call(char * alias_arg) {',
+        '    EXEC SQL BEGIN DECLARE SECTION;',
+        '    char * gl_server_alias = alias_arg;',
+        '    EXEC SQL END DECLARE SECTION;',
+        '',
+        '    EXEC SQL AT :gl_server_alias EXECUTE',
+        '    BEGIN',
+        '        make_call();',
+        '    END;',
+        '    END-EXEC;',
+        '}',
+    ]
+    registry = load_registry('.')
+    output, blocks = capture_exec_sql_blocks(ctx, lines, registry)
+    assert len(blocks) == 4


### PR DESCRIPTION
## Summary
- handle `EXEC SQL AT <conn> EXECUTE` blocks in registry
- add test covering EXECUTE blocks with connection spec

## Testing
- `PYTHONPATH=src pytest -q`
- `PYTHONPATH=src scripts/proc-format examples/basic/call-stored-procedure.pc foo.pc`


------
https://chatgpt.com/codex/tasks/task_b_6895c790caec8326ab2a99ef3fe7dee8