### PR TITLE
Fix Emacs parser parens and add debug log

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+## Environment
+All code you write must be compatible with:
+- Python 3.2.5
+- Cygwin 1.7.29
+- Oracle 12c

--- a/DEBUG_LOG.md
+++ b/DEBUG_LOG.md
@@ -1,0 +1,22 @@
+# DEBUG_LOG
+
+## 2025-08-08
+
+### Goals
+- Reproduce failing "Unterminated EXEC SQL STATEMENT-Multi-Line" test and collect initial diagnostics.
+
+### Actions
+- Attempted to run `(exec-sql-parser-parse ...)` using Emacs in batch mode, but loading `exec-sql-parser.el` raised `end-of-file` due to unbalanced parentheses.
+- Executed `emacs --batch exec-sql-parser.el -f check-parens` which reported "Unmatched bracket or quote".
+- Wrote a small Python script to locate the unmatched position, identifying an open parenthesis at the start of `exec-sql-parser-parse` (char 2652, ~line 87).
+- Added a missing closing parenthesis at the end of `exec-sql-parser.el` and re-ran `check-parens`, which succeeded.
+- With the file loadable, invoked the parser on a multi-line `EXEC SQL` block lacking a terminating semicolon. Emacs signaled `Unterminated EXEC SQL STATEMENT-Multi-Line`, producing a stack trace.
+
+### Results
+- Parser file now loads without syntax errors.
+- The targeted failing scenario reproduces reliably via batch invocation, yielding the expected error message and stack trace.
+
+### Next Steps
+- Analyze which portion of the parser determines block termination.
+- Investigate edge cases for multi-line SQL blocks and develop unit tests.
+- Implement parser fixes once root cause is identified.

--- a/exec-sql-parser.el
+++ b/exec-sql-parser.el
@@ -139,7 +139,7 @@ replacing EXEC SQL blocks, and CAPTURED is the list of captured blocks."
               (push line output)))))
     (when inside
       (error "Unterminated EXEC SQL %s" current-construct))
-    (list (nreverse output) (nreverse captured))))
+    (list (nreverse output) (nreverse captured)))))
 
 (provide 'exec-sql-parser)
 


### PR DESCRIPTION
## Summary
- fix unbalanced parenthesis in `exec-sql-parser.el` so it loads correctly
- start `DEBUG_LOG.md` and document steps taken to reproduce the failing multi-line EXEC SQL test

## Testing
- `emacs --batch exec-sql-parser.el -f check-parens`
- `emacs --batch -Q -l exec-sql-parser.el --eval "(exec-sql-parser-parse \"EXEC SQL\\nSELECT * FROM t\")"`
- `PYTHONPATH=src pytest tests/test_registry.py`

------
https://chatgpt.com/codex/tasks/task_b_6895c94062e88326a85df1341984b0ae