### PR TITLE
test: capture unterminated multi-line exec sql

### DIFF
--- a/tests/test_capture_exec_sql.py
+++ b/tests/test_capture_exec_sql.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 from proc_format.core import capture_exec_sql_blocks
 from proc_format.registry import load_registry
 
@@ -25,3 +26,17 @@ def test_execute_with_at_connection(tmp_path):
     registry = load_registry('.')
     output, blocks = capture_exec_sql_blocks(ctx, lines, registry)
     assert len(blocks) == 4
+
+
+def test_unterminated_multi_line(tmp_path):
+    sql_dir = tmp_path / 'sql'
+    os.makedirs(str(sql_dir))
+    ctx = type('Ctx', (), {'sql_dir': str(sql_dir)})
+    lines = [
+        'EXEC SQL',
+        'SELECT * FROM t',
+    ]
+    registry = load_registry('.')
+    with pytest.raises(ValueError) as excinfo:
+        capture_exec_sql_blocks(ctx, lines, registry)
+    assert 'Unterminated EXEC SQL STATEMENT-Multi-Line' in str(excinfo.value)


### PR DESCRIPTION
## Summary
- add regression test to document unterminated multi-line EXEC SQL block behavior
- log additional investigation session capturing test run and current failure

## Testing
- `make e-eval` *(fails: Unterminated EXEC SQL STATEMENT-Multi-Line)*
- `PYTHONPATH=src pytest tests/test_capture_exec_sql.py::test_unterminated_multi_line -q`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6895d7558ebc8326ad9d2e4225799c34