### PR TITLE
Handle EOF termination for EXEC SQL blocks

### DIFF
--- a/exec-sql-parser.el
+++ b/exec-sql-parser.el
@@ -138,7 +138,8 @@ replacing EXEC SQL blocks, and CAPTURED is the list of captured blocks."
             (unless matched
               (push line output)))))
     (when inside
-      (error "Unterminated EXEC SQL %s" current-construct))
+      (push (nreverse current-block) captured)
+      (push (exec-sql-parser--marker marker-counter) output))
     (list (nreverse output) (nreverse captured)))))
 
 (provide 'exec-sql-parser)

--- a/src/proc_format/core.py
+++ b/src/proc_format/core.py
@@ -156,10 +156,17 @@ def capture_exec_sql_blocks(ctx, lines, registry):
     print()
 
     if inside_block:
-        raise ValueError(
-            "Unterminated EXEC SQL {0} detected at line {1}:\n{2}"
-                .format(current_construct, line_number, "\n".join(current_block))
-        )
+        marker = get_marker(marker_counter)
+        output_lines.append(marker)
+        captured_blocks.append(current_handler["action"](current_block))
+        with open_file(ctx.sql_dir, marker_counter) as f:
+            f.write(("Construct:  '{0}'\n".format(current_construct))
+                   +("Pattern:    '{0}'\n".format(current_handler["pattern"]))
+                   +("EndPattern: '{0}'\n\n".format(current_handler["end_pattern"]))
+                   +("Stripped:  '{0}'\n\n".format(current_stripped_line))
+                   +("\n".join(current_block)+"\n\n"))
+        marker_counter += 1
+        print("b", end="")
 
     return output_lines, captured_blocks
 

--- a/tests/test_capture_exec_sql.py
+++ b/tests/test_capture_exec_sql.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from proc_format.core import capture_exec_sql_blocks
+from proc_format.core import capture_exec_sql_blocks, get_marker
 from proc_format.registry import load_registry
 
 
@@ -28,7 +28,7 @@ def test_execute_with_at_connection(tmp_path):
     assert len(blocks) == 4
 
 
-def test_unterminated_multi_line(tmp_path):
+def test_multi_line_terminated_at_eof(tmp_path):
     sql_dir = tmp_path / 'sql'
     os.makedirs(str(sql_dir))
     ctx = type('Ctx', (), {'sql_dir': str(sql_dir)})
@@ -37,6 +37,6 @@ def test_unterminated_multi_line(tmp_path):
         'SELECT * FROM t',
     ]
     registry = load_registry('.')
-    with pytest.raises(ValueError) as excinfo:
-        capture_exec_sql_blocks(ctx, lines, registry)
-    assert 'Unterminated EXEC SQL STATEMENT-Multi-Line' in str(excinfo.value)
+    output, blocks = capture_exec_sql_blocks(ctx, lines, registry)
+    assert output == [get_marker(1)]
+    assert blocks == [lines]


### PR DESCRIPTION
## Summary
- Allow EXEC SQL blocks without a terminating marker to end at EOF in the Emacs and Python parsers
- Add coverage ensuring an unterminated block is captured instead of erroring
- Record debugging progress for EOF handling of multi-line statements
- Log follow-up investigation into evaluating handler actions at EOF in the Emacs parser

## Testing
- `PYTHONPATH=src pytest -q`
- `make e-eval`


------
https://chatgpt.com/codex/tasks/task_b_6895eb5736bc8326a9168061c5076696