### PR TITLE
Handle unterminated EXEC SQL blocks

### DIFF
--- a/exec-sql-parser.el
+++ b/exec-sql-parser.el
@@ -224,9 +224,12 @@ REGISTRY defaults to `exec-sql-parser-registry`."
             (unless matched
               (push line output))))))
     (when inside
-      (error "Unterminated EXEC SQL %s" current-construct))
+      (push (funcall (exec-sql-parser--action-fn
+                      (plist-get current-handler :action))
+                     (nreverse current-block))
+            captured)
+      (push (exec-sql-parser--marker marker-counter) output))
     (list (nreverse output) (nreverse captured))))
-  )
 
 (provide 'exec-sql-parser)
 


### PR DESCRIPTION
## Summary
- ensure exec-sql-parser handles unterminated EXEC SQL forms without raising an error

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68966bbecd9483269bc0908667fd817a