### PR TITLE
Improve documentation and tests for SQL block formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 
 # Proc Formatter
 
-A script for processing and formatting code.
+Formats Pro*C source files by aligning `EXEC SQL` blocks with the surrounding C code.  Each SQL block is temporarily replaced by a numbered marker, the remaining C code is processed by `clang-format`, and the original SQL text is restored.
 
 ## Usage
 
 ```bash
 python -m proc_format input_file output_file
 ```
+
+The tool requires access to a `clang-format` executable.
 
 ### Configuration
 

--- a/src/proc_format/registry.py
+++ b/src/proc_format/registry.py
@@ -144,6 +144,13 @@ DEFAULT_EXEC_SQL_REGISTRY = {
 }
 
 def load_registry(start_dir, search_parents=True):
+    """Load EXEC SQL patterns starting at ``start_dir``.
+
+    Configuration files named ``.exec-sql-parser`` are read from
+    ``start_dir`` and optionally its ancestors.  Each file may add or
+    remove entries from the default registry.  When ``search_parents`` is
+    ``False`` only the starting directory is considered.
+    """
     registry = DEFAULT_EXEC_SQL_REGISTRY.copy()
     path = os.path.abspath(start_dir)
     configs = []

--- a/tests/test_capture_exec_sql.py
+++ b/tests/test_capture_exec_sql.py
@@ -5,6 +5,7 @@ from proc_format.registry import load_registry
 
 
 def test_execute_with_at_connection(tmp_path):
+    # Validates parsing of EXECUTE statements with an AT clause.
     sql_dir = tmp_path / 'sql'
     os.makedirs(str(sql_dir))
     ctx = type('Ctx', (), {'sql_dir': str(sql_dir)})
@@ -29,6 +30,7 @@ def test_execute_with_at_connection(tmp_path):
 
 
 def test_multi_line_terminated_at_eof(tmp_path):
+    # Ensures a multi-line statement ending at EOF is captured.
     sql_dir = tmp_path / 'sql'
     os.makedirs(str(sql_dir))
     ctx = type('Ctx', (), {'sql_dir': str(sql_dir)})

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,11 +1,11 @@
 import os
 import tempfile
 import shutil
+from collections import OrderedDict
 
 from proc_format.registry import load_registry
 from proc_format.registry import DEFAULT_EXEC_SQL_REGISTRY
 from proc_format import core
-from collections import OrderedDict
 
 
 def write_cfg(dirpath, content):
@@ -16,6 +16,7 @@ def write_cfg(dirpath, content):
 
 
 def test_registry_override_and_disable():
+    # Confirm that local configuration disables and adds registry entries.
     base = tempfile.mkdtemp()
     try:
         write_cfg(base, '{"STATEMENT-Single-Line [1]": null}')
@@ -32,6 +33,7 @@ def test_registry_override_and_disable():
 
 
 def test_registry_no_parents():
+    # Verify parent directories are ignored when search_parents is False.
     base = tempfile.mkdtemp()
     try:
         write_cfg(base, '{"STATEMENT-Single-Line [1]": null}')
@@ -44,6 +46,7 @@ def test_registry_no_parents():
 
 
 def test_registry_root_stops_search():
+    # Ensure a config with "root": true halts upward search.
     base = tempfile.mkdtemp()
     try:
         write_cfg(base, '{"STATEMENT-Single-Line [1]": null}')
@@ -59,6 +62,7 @@ def test_registry_root_stops_search():
 
 
 def test_capture_exec_sql_blocks_variants():
+    # Validate capture_exec_sql_blocks handles known registry variants.
     path = os.path.join(os.path.dirname(__file__), 'data', 'exec_sql_variants.pc')
     f = open(path, 'r')
     lines = f.read().splitlines()

--- a/tests/test_restore_exec_sql_blocks.py
+++ b/tests/test_restore_exec_sql_blocks.py
@@ -1,0 +1,19 @@
+import pytest
+from proc_format.core import restore_exec_sql_blocks, get_marker
+
+
+def test_restore_exec_sql_blocks_with_indent():
+    # Validates that SQL segments replace markers and adopt the marker's indentation.
+    content = "void f()\n{\n    " + get_marker(1) + "\n}"
+    segments = [["EXEC SQL SELECT 1;", "END-EXEC;"]]
+    restored = restore_exec_sql_blocks(content, segments)
+    expected = "void f()\n{\n    EXEC SQL SELECT 1;\n    END-EXEC;\n}"
+    assert restored == expected
+
+
+def test_restore_exec_sql_blocks_missing_segment():
+    # Ensures that unused captured segments trigger an error.
+    content = get_marker(1)
+    segments = [["EXEC SQL SELECT 1;"], ["EXEC SQL SELECT 2;"]]
+    with pytest.raises(ValueError):
+        restore_exec_sql_blocks(content, segments)


### PR DESCRIPTION
## Summary
- document ProC formatter context and workflow
- clarify registry loading behavior
- test SQL block restoration and ensure tests describe coverage
- restore TODO and encoding comments omitted in previous revision

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6896718965dc8326b564472de20dab03