### PR TITLE
Add function to count remaining EXEC SQL statements

### DIFF
--- a/exec-sql-parser.el
+++ b/exec-sql-parser.el
@@ -291,6 +291,25 @@ function may be called repeatedly to traverse statements."
       (goto-char (+ (point-min) (plist-get info :offset))))
     info))
 
+(defun execl-sql-count-remaining (&optional registry)
+  "Return number of remaining EXEC SQL statements after point.
+
+When a region is active, only the portion from point to the end of the
+region is considered.  Internally uses `exec-sql-goto-next' to traverse
+statements.  Point is restored to its original location after counting.
+REGISTRY defaults to `exec-sql-parser-registry'."
+  (interactive)
+  (let ((count 0))
+    (save-excursion
+      (save-restriction
+        (when (use-region-p)
+          (narrow-to-region (point) (region-end)))
+        (while (exec-sql-goto-next registry)
+          (setq count (1+ count)))))
+    (when (called-interactively-p 'interactive)
+      (message "%d" count))
+    count))
+
 (provide 'exec-sql-parser)
 
 ;;; exec-sql-parser.el ends here


### PR DESCRIPTION
## Summary
- add `execl-sql-count-remaining` to count remaining EXEC SQL statements from point to buffer or region end

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_6897051da8108326bde06af1ce4fddcd