### PR TITLE
Skip commented EXEC SQL statements in goto-next

### DIFF
--- a/exec-sql-parser.el
+++ b/exec-sql-parser.el
@@ -260,8 +260,12 @@ found, nil is returned.  REGISTRY defaults to
             (if (null candidate)
                 (setq start nil)
               (let ((pos (car candidate)))
-                (goto-char pos)
-                (setq result (list :pos pos :entry (cdr candidate))))))))
+                (if (and exec-sql-parser-ignore-comments
+                         (nth 4 (syntax-ppss pos)))
+                    (setq start (1+ pos))
+                  (progn
+                    (goto-char pos)
+                    (setq result (list :pos pos :entry (cdr candidate))))))))))
     (when result
       (let* ((entry (plist-get result :entry))
              (start (plist-get result :pos))

--- a/tests/test_exec_sql_parser.el
+++ b/tests/test_exec_sql_parser.el
@@ -147,6 +147,18 @@ string.  Errors are signaled when markers and segments do not align."
       (should (= (current-column) 2))
       (should (equal (point) (+ (point-min) (plist-get info :offset)))))))
 
+(ert-deftest exec-sql-parser-goto-next-skips-comments ()
+  (with-temp-buffer
+    (c-mode)
+    (insert "int x;\nEXEC SQL SELECT 1;\n/*\nEXEC SQL SELECT 2;\n*/\nEXEC SQL SELECT 3;\n")
+    (goto-char (point-min))
+    (let ((first (exec-sql-goto-next)))
+      (should first)
+      (should (= (line-number-at-pos) 2)))
+    (let ((second (exec-sql-goto-next)))
+      (should second)
+      (should (= (line-number-at-pos) 6)))))
+
 (ert-deftest exec-sql-parser-get-next-across-types ()
   "`exec-sql-get-next' should return the earliest statement regardless of construct order."
   (with-temp-buffer


### PR DESCRIPTION
## Summary
- test that `exec-sql-goto-next` ignores commented EXEC SQL blocks
- skip EXEC SQL matches inside comments when searching for next statement

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68972294240c83268093785eef8ae774