### PR TITLE
Clarify block handling and add clang formatter encoding tests

### DIFF
--- a/src/proc_format/core.py
+++ b/src/proc_format/core.py
@@ -136,7 +136,8 @@ def capture_exec_sql_blocks(ctx, lines, registry):
         stripped_line = line.strip()
         if inside_block:
             current_block.append(line)  # Continue accumulating block
-            # TODO: should check END pattern but is often fails
+            # Detect the end of the current block using the handler's
+            # ``end_pattern``.
             if re.match(current_handler["end_pattern"], stripped_line):
                 # Block has ended; replace it with a marker
                 marker = get_marker(marker_counter)
@@ -209,8 +210,8 @@ def format_with_clang(ctx, content):
 
     ``ctx.clang_format_path`` is executed as a subprocess.  Any
     ``clang-format`` failure results in ``RuntimeError``.  On Python
-    versions earlier than 3.7 the function handles the byte/string
-    conversions explicitly.
+    versions earlier than 3.7 the function encodes the input to bytes
+    to satisfy ``subprocess``'s expectations.
     """
     print("- Apply clang-format to C code content ...")
     popen_additional_args = {}
@@ -218,7 +219,7 @@ def format_with_clang(ctx, content):
         popen_additional_args["text"] = True
     else:
         # Python 3.2 subprocess expects byte strings
-        if True : # if hasattr(content, "encode"):
+        if hasattr(content, "encode"):
             content = content.encode()
     process = subprocess.Popen([ctx.clang_format_path],
             stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,

--- a/tests/test_format_with_clang.py
+++ b/tests/test_format_with_clang.py
@@ -1,0 +1,45 @@
+import sys
+import subprocess
+from proc_format.core import format_with_clang
+
+
+class DummyCtx(object):
+    clang_format_path = 'clang-format'
+
+
+def test_format_with_clang_encodes_input(monkeypatch):
+    # Validates that content is encoded to bytes on Python versions before 3.7.
+    captured = {}
+
+    class DummyPopen(object):
+        def __init__(self, *args, **kwargs):
+            self.returncode = 0
+        def communicate(self, input=None):
+            captured['input'] = input
+            return input, b''
+
+    monkeypatch.setattr(subprocess, 'Popen', DummyPopen)
+    monkeypatch.setattr(sys, 'version_info', (3, 6, 0))
+    content = 'int x;'
+    result = format_with_clang(DummyCtx, content)
+    assert captured['input'] == content.encode()
+    assert result == content
+
+
+def test_format_with_clang_text_mode(monkeypatch):
+    # Ensures text input is preserved when Python 3.7+ is detected.
+    captured = {}
+
+    class DummyPopen(object):
+        def __init__(self, *args, **kwargs):
+            self.returncode = 0
+        def communicate(self, input=None):
+            captured['input'] = input
+            return input, ''
+
+    monkeypatch.setattr(subprocess, 'Popen', DummyPopen)
+    monkeypatch.setattr(sys, 'version_info', (3, 7, 0))
+    content = 'int y;'
+    result = format_with_clang(DummyCtx, content)
+    assert captured['input'] == content
+    assert result == content


### PR DESCRIPTION
## Summary
- Clarify how EXEC SQL block endings are detected in `capture_exec_sql_blocks`
- Ensure `format_with_clang` encodes input for Python <3.7 and document the behavior
- Add tests covering byte/text handling in `format_with_clang`

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68972cbe154083269e2f02cd584f74ef