### PR TITLE
Ensure specific EXEC SQL patterns match before generic ones

### DIFF
--- a/src/proc_format/core.py
+++ b/src/proc_format/core.py
@@ -191,6 +191,15 @@ def capture_exec_sql_blocks(ctx, lines, registry):
     marker_counter = 1  # Sequential counter for unique markers
 
     print("- Capture EXEC SQL segments ...")
+    # Ensure specific patterns are matched before generic ones.  Python 3.2
+    # dictionaries do not preserve insertion order, so ``registry`` entries
+    # are sorted by the length of their pattern with longer (more specific)
+    # patterns evaluated first.
+    registry_items = sorted(
+        registry.items(),
+        key=lambda item: len(item[1].get("pattern", "")),
+        reverse=True,
+    )
 
     for line_number, line in enumerate(lines, 1):
         stripped_line = line.strip()
@@ -220,7 +229,7 @@ def capture_exec_sql_blocks(ctx, lines, registry):
                 current_stripped_line = None
                 print("b", end="")
         else:
-            for construct, details in registry.items():
+            for construct, details in registry_items:
                 if re.match(details["pattern"], stripped_line):
                     if "error" in details:
                         raise ValueError("Unaccompanied block end marker detected at line {0}:\n{1}"

--- a/tests/test_capture_exec_sql.py
+++ b/tests/test_capture_exec_sql.py
@@ -27,6 +27,13 @@ def test_execute_with_at_connection(tmp_path):
     registry = load_registry('.')
     output, blocks = capture_exec_sql_blocks(ctx, lines, registry)
     assert len(blocks) == 4
+    assert blocks[3] == [
+        '    EXEC SQL AT :gl_server_alias EXECUTE',
+        '    BEGIN',
+        '        make_call();',
+        '    END;',
+        '    END-EXEC;',
+    ]
 
 
 def test_multi_line_terminated_at_eof(tmp_path):


### PR DESCRIPTION
## Summary
- sort EXEC SQL registry patterns by length so specific constructs are matched before generic ones
- validate EXECUTE blocks are captured completely with a regression test

## Testing
- `PYTHONPATH=src pytest tests`
- `PYTHONPATH=src python -m proc_format examples/basic/oracle+addtl.pc foo.pc`

------
https://chatgpt.com/codex/tasks/task_b_689c40bd96d08326adc7f5eb51c0ba55