### PR TITLE
Add verbose logging option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Ensure `clang-format` is available on your system.
 python -m proc_format input_file output_file
 ```
 
+Use `-v`/`--verbose` for progress details. Repeat the flag (e.g., `-vvv`) to
+increase verbosity. Warnings about skipped `sqlparse` formatting are emitted by
+default; suppress them with `--terse` or silence all output with `--silent`.
+
 ### Configuration
 
 `proc_format` can read additional EXEC SQL parsing patterns from a file named `.exec-sql-parser`. The file is searched in the directory of the input file and its ancestors with entries in lower directories overriding higher ones. Each file is a JSON object where keys are pattern names. Setting a name to `null` disables the built-in pattern; providing an object with `"pattern"` and optional `"end_pattern"` adds or replaces a pattern. A file may contain `"root": true` to stop searching for configurations in higher directories. Use `--no-registry-parents` to only consider the configuration file in the input file's directory.

--- a/src/proc_format/__main__.py
+++ b/src/proc_format/__main__.py
@@ -18,6 +18,12 @@ def main():
     parser.add_argument("--keep", action="store_true", help="Do not delete debug directory before processing.")
     parser.add_argument("--no-registry-parents", action="store_true",
                         help="Do not search parent directories for .exec-sql-parser files.")
+    parser.add_argument("--terse", action="store_true",
+                        help="Suppress non-critical warnings.")
+    parser.add_argument("--silent", action="store_true",
+                        help="Suppress all output.")
+    parser.add_argument("-v", "--verbose", action="count", default=0,
+                        help="Increase verbosity; repeat for more detail.")
 
     args = parser.parse_args()
 

--- a/tests/test_verbose.py
+++ b/tests/test_verbose.py
@@ -1,0 +1,34 @@
+import pytest
+from proc_format.core import format_exec_sql_block
+
+pytest.importorskip('sqlparse')
+
+
+class Ctx(object):
+    def __init__(self, verbose=0, terse=False, silent=False):
+        self.verbose = verbose
+        self.terse = terse
+        self.silent = silent
+
+
+def test_verbose_reports_sqlparse_use(capsys):
+    lines = ['EXEC SQL select * from dual;']
+    format_exec_sql_block(lines, 'STATEMENT-Single-Line [1]', Ctx(1))
+    out = capsys.readouterr().out
+    assert 'sqlparse: formatting' in out
+
+
+def test_warns_when_sqlparse_skipped(capsys):
+    lines = ['EXEC ORACLE OPTION (hold_cursor=yes);']
+    format_exec_sql_block(lines, 'ORACLE-Single-Line [1]', Ctx())
+    err = capsys.readouterr().err
+    assert 'sqlparse: skipped' in err
+
+
+@pytest.mark.parametrize("ctx", [Ctx(terse=True), Ctx(silent=True)])
+def test_warn_suppressed_with_terse_or_silent(ctx, capsys):
+    lines = ['EXEC ORACLE OPTION (hold_cursor=yes);']
+    format_exec_sql_block(lines, 'ORACLE-Single-Line [1]', ctx)
+    out = capsys.readouterr()
+    assert out.err == ''
+


### PR DESCRIPTION
## Summary
- warn when sqlparse formatting is skipped unless --terse or --silent
- add --terse and --silent CLI flags
- cover warnings and suppression in tests

## Testing
- `PYTHONPATH=src pytest tests`

------
https://chatgpt.com/codex/tasks/task_b_689c53202ab08326a0e3210d2dbcb2d6