### PR TITLE
Display configuration sources at verbose level

### DIFF
--- a/src/proc_format/core.py
+++ b/src/proc_format/core.py
@@ -60,13 +60,14 @@ class ProCFormatterContext:
         self.keep = args.keep
         self.debug = args.debug
         self.sql_dir = os.path.join(self.debug, SQL_DIR)
-        search = not getattr(args, 'no_registry_parents', False)
-        # The registry is loaded from ``.exec-sql-parser`` files in the
-        # directory tree containing ``input_file``.
-        self.registry = load_registry(os.path.dirname(self.input_file), search)
         self.verbose = getattr(args, 'verbose', 0)
         self.terse = getattr(args, 'terse', False)
         self.silent = getattr(args, 'silent', False)
+        search = not getattr(args, 'no_registry_parents', False)
+        # The registry is loaded from ``.exec-sql-parser`` files in the
+        # directory tree containing ``input_file``.
+        self.registry = load_registry(os.path.dirname(self.input_file), search,
+                                      self.verbose)
 
 def format_name(debug_dir, *elements):
     elements = [str(e) for e in elements]

--- a/src/proc_format/registry.py
+++ b/src/proc_format/registry.py
@@ -150,7 +150,7 @@ DEFAULT_EXEC_SQL_REGISTRY = {
     }
 }
 
-def load_registry(start_dir, search_parents=True):
+def load_registry(start_dir, search_parents=True, verbose=0):
     """Load EXEC SQL patterns starting at ``start_dir``.
 
     Configuration files named ``.exec-sql-parser`` are read from
@@ -158,6 +158,8 @@ def load_registry(start_dir, search_parents=True):
     remove entries from the default registry.  When ``search_parents`` is
     ``False`` only the starting directory is considered.
     """
+    if verbose >= 1:
+        print('Loading default configuration options')
     registry = DEFAULT_EXEC_SQL_REGISTRY.copy()
     path = os.path.abspath(start_dir)
     configs = []
@@ -170,7 +172,7 @@ def load_registry(start_dir, search_parents=True):
                 f.close()
             except Exception:
                 data = {}
-            configs.append(data)
+            configs.append((cfg_path, data))
             if data.get('root'):
                 break
         parent = os.path.dirname(path)
@@ -178,7 +180,9 @@ def load_registry(start_dir, search_parents=True):
             break
         path = parent
     configs.reverse()
-    for data in configs:
+    for cfg_path, data in configs:
+        if verbose >= 1:
+            print('Loading configuration options from {0}'.format(cfg_path))
         for name, value in data.items():
             if name == 'root':
                 continue

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -61,6 +61,24 @@ def test_registry_root_stops_search():
         shutil.rmtree(base)
 
 
+def test_load_registry_verbose(capsys):
+    # Ensure verbose output lists configuration file sources.
+    base = tempfile.mkdtemp()
+    try:
+        write_cfg(base, '{"STATEMENT-Single-Line [1]": null}')
+        sub = os.path.join(base, 'sub')
+        os.mkdir(sub)
+        write_cfg(sub, '{"CUSTOM": {"pattern": "EXEC SQL TEST;"}}')
+        load_registry(sub, verbose=1)
+        captured = capsys.readouterr()
+        base_cfg = os.path.join(base, '.exec-sql-parser')
+        sub_cfg = os.path.join(sub, '.exec-sql-parser')
+        assert base_cfg in captured.out
+        assert sub_cfg in captured.out
+    finally:
+        shutil.rmtree(base)
+
+
 def test_capture_exec_sql_blocks_variants():
     # Validate capture_exec_sql_blocks handles known registry variants.
     path = os.path.join(os.path.dirname(__file__), 'data', 'exec_sql_variants.pc')


### PR DESCRIPTION
## Summary
- show default and per-file registry configuration sources when verbosity is enabled
- pass through verbose flag from ProCFormatterContext to registry loader
- test that verbose mode reports loaded configuration files

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689c93a597ec8326ab5ede6737b9e48d