### PR TITLE
Propagate verbosity to sqlformat subprocess

### DIFF
--- a/src/proc_format/core.py
+++ b/src/proc_format/core.py
@@ -175,11 +175,15 @@ def format_exec_sql_block(lines, construct, ctx=None):
         sql_lines.append(line.strip())
     sql_text = "\n".join(sql_lines)
     vprint(ctx, 1, "sqlparse: formatting EXEC SQL block")
+    old_verbosity = getattr(sqlparse, 'verbosity', 0)
+    sqlparse.verbosity = getattr(ctx, 'verbose', 0)
     try:
         formatted = sqlparse.format(sql_text, keyword_case='upper')
     except Exception as e:
         warn(ctx, "sqlparse: skipped - sqlparse error: {0}".format(e))
         return lines
+    finally:
+        sqlparse.verbosity = old_verbosity
     formatted_lines = formatted.splitlines()
     output = []
     if formatted_lines:

--- a/tests/test_verbose.py
+++ b/tests/test_verbose.py
@@ -32,3 +32,18 @@ def test_warn_suppressed_with_terse_or_silent(ctx, capsys):
     out = capsys.readouterr()
     assert out.err == ''
 
+
+def test_sqlparse_receives_verbosity(monkeypatch):
+    import sqlparse
+
+    recorded = {}
+
+    def fake_format(sql_text, **options):
+        recorded['verbosity'] = sqlparse.verbosity
+        return sql_text
+
+    monkeypatch.setattr(sqlparse, 'format', fake_format)
+    lines = ['EXEC SQL select * from dual;']
+    format_exec_sql_block(lines, 'STATEMENT-Single-Line [1]', Ctx(3))
+    assert recorded['verbosity'] == 3
+


### PR DESCRIPTION
## Summary
- Propagate CLI verbosity to sqlparse before formatting EXEC SQL blocks so sqlformat honors the same level
- Add regression test verifying the verbosity level is forwarded

## Testing
- `pip install 'sqlparse>=0.5,<0.6'` *(failed: Could not find a version that satisfies the requirement sqlparse<0.6,>=0.5)*
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_b_689cbf0c6ff48326882cc98539fd591b